### PR TITLE
Remove max-width from comments

### DIFF
--- a/wide-my-github.css
+++ b/wide-my-github.css
@@ -35,6 +35,10 @@
   .list-group-item-meta .branch-name .css-truncate-target {
     max-width: 100% !important;
   }
+  #comments,
+  .comment-holder {
+    max-width: inherit !important;
+  }
 }
 
 @-moz-document domain("gist.github.com") {


### PR DESCRIPTION
This removes the maximum width from comments on pull requests, causing them to fill all available width. I admittedly haven't tested it beyond its immediate, obvious effects.
