### PR TITLE
Hard code (higher) max-width for comments.

### DIFF
--- a/wide-my-github.css
+++ b/wide-my-github.css
@@ -37,7 +37,7 @@
   }
   #comments,
   .comment-holder {
-    max-width: inherit !important;
+    max-width: 1100px !important;
   }
 }
 


### PR DESCRIPTION
#2 turned out to have negative side effects in the context of code lines that are wider than the screen width. This puts a reasonable hard limit on it that works well down to a screen resolution of 1280x800 (which, incidentally, is what I think I'll start using as the functional baseline).
